### PR TITLE
Update readme to use the main branch of facebook/rocksdb

### DIFF
--- a/.github/actions/pre-steps-macos/action.yml
+++ b/.github/actions/pre-steps-macos/action.yml
@@ -4,7 +4,7 @@ runs:
   steps:
   - name: Clone rocksdb
     run: |
-      git clone --depth 1 --branch v8.5.3 https://github.com/facebook/rocksdb.git
+      git clone --depth 1 https://github.com/facebook/rocksdb.git
     shell: bash
   - uses: actions/checkout@v4
     with:

--- a/.github/actions/pre-steps/action.yml
+++ b/.github/actions/pre-steps/action.yml
@@ -11,7 +11,7 @@ runs:
     shell: bash
   - name: Clone rocksdb
     run: |
-      git clone --depth 1 --branch v8.5.3 https://github.com/facebook/rocksdb.git
+      git clone --depth 1 https://github.com/facebook/rocksdb.git
     shell: bash
   - uses: actions/checkout@v4
     with:

--- a/.github/workflows/sanity_check.yml
+++ b/.github/workflows/sanity_check.yml
@@ -23,7 +23,7 @@ jobs:
       run: pip install argparse
     - name: Clone rocksdb
       run: |
-        git clone --depth 1 --branch v8.5.3 https://github.com/facebook/rocksdb.git
+        git clone --depth 1 https://github.com/facebook/rocksdb.git
       shell: bash
     - uses: actions/checkout@v4
       with:

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 The `AESEncryptionProvider` of `EncryptionFileSystem` is an encryption plugin for RocksDB. It depends on OpenSSL to show how an external plugin can bring its dependencies into the RocksDB build. It provides a factory function in a header file to show integration with RocksDB header includes. It can also be enabled in text-based options to demonstrate use of the static registration framework.
 
 ## Build
-Download the RocksDB code from the official repository. Currently, version 8.5.3 is used as the benchmark for testing.
+Download the RocksDB code from the official repository.
 
 ```
-git clone --depth 1 --branch v8.5.3 https://github.com/facebook/rocksdb.git
+git clone --depth 1 https://github.com/facebook/rocksdb.git
 ```
 
 The code first needs to be linked under RocksDB's `plugin/` directory. In your RocksDB directory, run:


### PR DESCRIPTION
Because there are some patches only pushed to the `main` branch of facebook/rocksdb,
but not on the branch `v8.5.3`, the patches are plugin unit tests related, the unit
tests will not act as expected without these patches. So it would be better to use
the `main` branch in README.md

The patches are:
https://github.com/facebook/rocksdb/commit/76402c034e8fa75809df3ed89a5742f044e980e9
https://github.com/facebook/rocksdb/commit/c4c62c230438b06bae67189baaa5a7661e590160